### PR TITLE
fix: add parameterized queries in log.php

### DIFF
--- a/logedit/log.php
+++ b/logedit/log.php
@@ -64,10 +64,10 @@ if ($lockguid != "") {
         $faketime = 0;
         $rowcount = 0;
 
-        $sql = "SELECT * FROM LOG_LINES WHERE LOG_NAME = '$id' ORDER BY COUNT ASC";
+        $sql = "SELECT * FROM LOG_LINES WHERE LOG_NAME = ? ORDER BY COUNT ASC";
         $stmt = $db->prepare($sql);
         $stmt->setFetchMode(PDO::FETCH_ASSOC);
-        $stmt->execute();
+        $stmt->execute(array($id));
         while ($row = $stmt->fetch()) {
             $cartno = $row['CART_NUMBER'];
             $sql2 = "SELECT * FROM CART grid LEFT JOIN GROUPS clk ON grid.GROUP_NAME=clk.NAME WHERE grid.NUMBER = '$cartno'";
@@ -178,10 +178,10 @@ if ($lockguid != "") {
         $timebefore = 0;
         $faketime = 0;
         $rowcount = 0;
-        $sql = "SELECT * FROM LOG_LINES WHERE LOG_NAME = '$id' ORDER BY COUNT ASC";
+        $sql = "SELECT * FROM LOG_LINES WHERE LOG_NAME = ? ORDER BY COUNT ASC";
         $stmt = $db->prepare($sql);
         $stmt->setFetchMode(PDO::FETCH_ASSOC);
-        $stmt->execute();
+        $stmt->execute(array($id));
         while ($row = $stmt->fetch()) {
             $cartno = $row['CART_NUMBER'];
             $sql2 = "SELECT * FROM CART grid LEFT JOIN GROUPS clk ON grid.GROUP_NAME=clk.NAME WHERE grid.NUMBER = '$cartno'";


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `logedit/log.php`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `logedit/log.php:67` |
| **Assessment** | Likely exploitable |
| **CWE** | CWE-89 |
| **Chain Complexity** | 2-step |

**Description**: The $id parameter from user input is directly concatenated into SQL queries without sanitization or parameterization. This classic SQL injection vulnerability appears at two locations in logedit/log.php (lines 67 and 181), allowing arbitrary SQL command execution.

## Evidence

**Exploitation scenario**: Attacker sends HTTP GET request to logedit/log.php with malicious $id parameter.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Changes
- `logedit/log.php`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-001 scanner=multi_agent_ai -->
